### PR TITLE
Add proof-of-concept integration with Touca

### DIFF
--- a/battle_wizard/tests.py
+++ b/battle_wizard/tests.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 import time
+import touca
 from unittest import skip
 
 from channels.db import database_sync_to_async
@@ -14,12 +15,16 @@ from battle_wizard.models import Deck
 from battle_wizard.game.game import Game
 from battle_wizard.models import GameRecord
 from battle_wizard.models import GlobalDeck
+from battle_wizard.game.card import Card
 from battle_wizard.game.player import Player
 from battle_wizard.game.player_ai import PlayerAI
 from battle_wizard.views import add_default_decks
 from channels.testing import WebsocketCommunicator
 from django.contrib.auth.models import User
 
+touca.add_serializer(Game, lambda game: game.as_dict())
+touca.add_serializer(Player, lambda player: player.as_dict())
+touca.add_serializer(Card, lambda card: card.as_dict())
 
 class GameObjectTests(TransactionTestCase):
 
@@ -147,6 +152,7 @@ class GameObjectTests(TransactionTestCase):
             game.play_move({"username": "a", "move_type": "END_TURN"})
             game.play_move({"username": "b", "move_type": "END_TURN"})
         self.assertEqual(len(game.current_player().hand), game.max_hand_size)
+        touca.add_result('hand_size', len(game.current_player().hand))
 
     def test_ten_mana_limit(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ daphne==3.0.1
 psycopg2-binary==2.8.6
 python-decouple==3.3
 requests==2.26.0
+touca==0.2.6


### PR DESCRIPTION
## What's in this PR

This PR adds [Touca](https://pypi.org/project/touca/) as a development/test dependency and makes minimal use of the Touca extension for the Django Test Framework. This extension is new and was developed specifically to allow reuse of existing unit tests. While Touca is not a unit test framework, this approach allows easy evaluation of Touca without writing too much code.

This PR also adds a basic GitHub Actions CI workflow. This change can be regarded as a general improvement. However, the original intention was to showcase how Touca can be integrated with your CI pipeline to be run continuously after pushing or merging code.

## How does it work

With this PR you can continue to run unit-tests via `./manage.py test`.  The `touca` library will be no-op the entire time. Touca data capturing functions like `touca.add_result` won't capture results. When you want to try Touca, you can switch to using a customized version of the Django test framework that ships with Touca via `./manage.py test --testrunner touca.plugins.django.Runner`. The runner runs your existing unit tests and captures values of variables and runtimes of functions that are tracked by Touca data capturing functions. The test framework submits captured data to the Touca server when it is **configured** to do so.

You can track as many data points as needed from anywhere within your code. If the actual value of any of these tracked variables changes in a future version of your code, the Touca server finds that in near real-time and notifies you of the difference.

This PR limits using Touca to tracking a single variable in a single unit test. We'd need to track more data points to get real value from using Touca. For now, I just wanted to give you an idea of how using Touca would look like in this project.

## How to run it

You can configure the Touca client by passing API Key and API URL parameters and specifying the version of the code under test. You can find the API parameters in the suite page on `app.touca.io`. You can pass this information as command line options:

```bash
./manage.py test --testrunner touca.plugins.django.Runner --api-key <TOUCA_API_KEY> --api-url <TOUCA_API_URL> --revision 1.0
```

You can also set these parameters as environment variables.

```bash
export TOUCA_API_KEY=<TOUCA_API_KEY>
export TOUCA_API_URL=<TOUCA_API_URL>
export TOUCA_TEST_VERSION=1.0
./manage.py test --testrunner touca.plugins.django.Runner
```

See the CI workflow for an example where version is set to output of `git describe --abrev=4`.

Note that Touca SDKs support many more configuration options than our Django test runner and offer more functionality. We'll use your feedback to further improve our Django test framework. Happy to have a chat, show you more, and answer any questions in the process.