### PR TITLE
fixes sending too much data in GET_TIME

### DIFF
--- a/static/js/components/GameRoom.js
+++ b/static/js/components/GameRoom.js
@@ -61,7 +61,7 @@ export class GameRoom {
                         window.location.href = this.nextRoomUrl();
                     }, 100); 
                 }
-            } else if (message["move_type"] == "GET_TIME") {
+            } else if (!message["move_type"]) {
                 if (message["turn_time"] >= message["max_turn_time"]) {
                     this.gameUX.maybeShowRope();   
                 }

--- a/static/js/views/game.js
+++ b/static/js/views/game.js
@@ -524,7 +524,6 @@ export class GameUX {
                         if (message["defending_card"]) {
                             for (let boardSprite of this.app.stage.children) {
                                 if (boardSprite.card && message["defending_card"].id == boardSprite.card.id) {
-                                    console.log("FOUND IT")
                                     this.animateAttack(sprite, boardSprite, true);
                                 }
                             }


### PR DESCRIPTION
This PR removes all unneeded data from the GET_TIME requests that the client sends/receives every second or less.

I probably could have just removed the game key, but I removed everything that wasn't needed, including even the move_type.

LMK if it seems like a bad idea to remove the move_type, since that makes the code less legible slightly?